### PR TITLE
made call to std::min cross architecture safe

### DIFF
--- a/syncodecs.cc
+++ b/syncodecs.cc
@@ -529,7 +529,7 @@ void ShapedPacketizer::nextPacketOrFrame() {
     assert(m_secsToNextFrame >= 0);
 
     // m_payloadSize is interpreted here as "max payload size"
-    const unsigned long payloadSize = std::min(m_payloadSize, m_bytesToSend.size());
+    const unsigned long payloadSize = std::min<long unsigned int>(m_payloadSize, m_bytesToSend.size());
     const double packetsToSend = std::ceil((double)m_bytesToSend.size() / (double)(m_payloadSize));
     assert(packetsToSend >= 1.);
     const double secsToNextPacket = m_secsToNextFrame / packetsToSend;


### PR DESCRIPTION
Hi,

I had to compile your code on a i686 machine and came across an issue.
The Problem is that `std::vector<unsigned char>::size_type` is 64 bits on x86_64 and 32 bits on i686. So in my case the `std::min` function was called with a 64 bits and a 32 bits integer and the compiler didn't know which type to choose for the template and produced an error. This can be solved by specifying the template type directly.
